### PR TITLE
Exclude company details from job description output

### DIFF
--- a/frontend/src/utils/parseJobDescription.js
+++ b/frontend/src/utils/parseJobDescription.js
@@ -24,6 +24,6 @@ export const parseJobDescription = (description = "") => {
   const descriptionMain = match[1].trim();
 
   return (
-    <p>{descriptionMain}</p>
+    <p>{descriptionMain.split("company: ")[0]}</p>
   );
 };


### PR DESCRIPTION
Update the `parseJobDescription` function to remove company information from the main description returned.